### PR TITLE
添加手机号验证的单元测试代码，并且使用 jacoco 插件生成测试覆盖率报告

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,47 @@
 					</execution>
 				</executions>
 			</plugin>
+
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.6</version>
+				<executions>
+					<execution>
+						<id>default-prepare-agent</id>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>default-report</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>default-check</id>
+						<goals>
+							<goal>check</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<rule>
+									<element>BUNDLE</element>
+									<limits>
+										<limit>
+											<counter>COMPLEXITY</counter>
+											<value>COVEREDRATIO</value>
+											<minimum>0.60</minimum>
+										</limit>
+									</limits>
+								</rule>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/src/test/java/com/mushanwb/github/wxshop/service/TelVerificationServiceTest.java
+++ b/src/test/java/com/mushanwb/github/wxshop/service/TelVerificationServiceTest.java
@@ -1,0 +1,18 @@
+package com.mushanwb.github.wxshop.service;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class TelVerificationServiceTest {
+
+    @Test
+    public void returnTrueIfValid() {
+        Assertions.assertTrue(new TelVerificationService().verifyTelParameter("13812345678"));
+    }
+
+    @Test
+    public void returnFalseIfNotTel() {
+        Assertions.assertFalse(new TelVerificationService().verifyTelParameter(null));
+    }
+
+}


### PR DESCRIPTION
jacoco  需要在插件中将 report 绑定到一个阶段，最后生成的报告在 target/site/jacoco/index.html